### PR TITLE
Boost: Fix compilation issues caused by system boost's b2 site config

### DIFF
--- a/libraries/boost.cmake
+++ b/libraries/boost.cmake
@@ -63,6 +63,7 @@ SET(BOOST_B2_OPTIONS --prefix=${CONTRIB_INSTALL_BASE}
 		     --layout=tagged
 		     link=shared
 		     threading=multi
+		     --ignore-site-config
 )
 
 # Set system dependent variables


### PR DESCRIPTION
Although being compiled and installed separately in the contrib directory,
b2 seems to include configuration files from the system boost package, such as
`/usr/share/boost-build/site-config.jam`.

This causes problems at least under Gentoo Linux and doesn't look like this should be the expected behavior in any case.

See also:
http://stackoverflow.com/questions/23013433/how-to-install-modular-boost
